### PR TITLE
Quick build cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.2
 
-ENV HELPY_VERSION=1.1 \
+ENV HELPY_VERSION=1.1.0 \
     RAILS_ENV=production \
     HELPY_HOME=/helpy \
     HELPY_USER=helpyuser \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN sed -i '/ruby "2.2.1"/d' $HELPY_HOME/Gemfile
 
 # add the slack integration gem to the Gemfile if the HELPY_SLACK_INTEGRATION_ENABLED is true
 # use `test` for sh compatibility, also use only one `=`. also for sh compatibility
-RUN test "$HELPY_SLACK_INTEGRATION_ENABLED" = "true" && sed -i '$ a\gem "helpy_slack", github: "helpyio/helpy_slack", branch: "master"' $HELPY_HOME/Gemfile
+RUN test "$HELPY_SLACK_INTEGRATION_ENABLED" = "true" && sed -i '$ a\gem "helpy_slack", git: "https://github.com/helpyio/helpy_slack.git", branch: "master"' $HELPY_HOME/Gemfile
 
 RUN bundle install
 


### PR DESCRIPTION
Hey! I saw you're asking for a maintainer so I took a look at this image. I've never used helpy before, but it looks pretty useful! 

Things I fixed quick:
- The tag version was wrong. [1.1.0 was released not 1.1](https://github.com/helpyio/helpy/releases/tag/1.1.0)
- Clone helpyio_slack over https: [Docs](https://bundler.io/git.html)

There are some other fixes I can see right off the bat. 
- The image builds at ~1gb, which is really big. I think we could trim this down.
- No automated build. Docker hub has a free automated builds for open source projects. 
  - Example: https://github.com/adamdecaf/docker-znc
- Older versions
  - It looks like [some versions of deps are old](https://github.com/helpyio/helpy/issues/224) (running on ruby 2.2). I could help upgrade the container and deps. I'm not really a ruby dev, but I can work the basics. 

Issue: https://github.com/helpyio/helpy/issues/469